### PR TITLE
feat: Add OpenCode support as alternative CLI agent

### DIFF
--- a/run_example.py
+++ b/run_example.py
@@ -358,6 +358,9 @@ def main():
             mcp_port=mcp_port,
             monitoring_interval=monitoring_interval,
 
+            # Agent Configuration
+            default_cli_tool="claude",  # Options: "claude", "opencode", "codex"
+
             # Git Configuration
             main_repo_path=project_path,
             project_root=project_path,

--- a/src/agents/manager.py
+++ b/src/agents/manager.py
@@ -236,10 +236,11 @@ class AgentManager:
                 logger.error(f"Tmux session {session_name} died during initialization wait!")
                 raise Exception(f"Tmux session died during initialization wait")
 
-            # Send initial prompt with verification and retry
+            # Send initial prompt (or just Enter for OpenCode)
             await self._send_initial_prompt_with_retry(
                 pane=pane,
                 cli_agent=cli_agent,
+                cli_type=cli_type,
                 initial_message=initial_message,
                 agent_id=agent_id,
                 task_id=task.id,
@@ -604,6 +605,7 @@ REMEMBER:
         self,
         pane,
         cli_agent,
+        cli_type: str,
         initial_message: str,
         agent_id: str,
         task_id: str,
@@ -615,6 +617,7 @@ REMEMBER:
         Args:
             pane: tmux pane object
             cli_agent: CLI agent interface instance
+            cli_type: Type of CLI agent (claude, opencode, etc.)
             initial_message: The initial message to send
             agent_id: Agent ID for logging
             task_id: Task ID for verification
@@ -627,51 +630,80 @@ REMEMBER:
         # Use Task ID as verification string (always present in initial message)
         verification_string = f"Task ID: {task_id}"
 
+        # Check if this is OpenCode (prompt already loaded via -p flag)
+        is_opencode = cli_type == "opencode"
+
+        # Check if this is a Claude agent (needs chunking)
+        from src.interfaces.cli_interface import ClaudeCodeAgent
+        is_claude = isinstance(cli_agent, ClaudeCodeAgent)
+
         # If verification is disabled, just send once and return
         if not verify_delivery:
-            logger.info(f"Sending initial prompt to agent {agent_id} (verification disabled)")
+            if is_opencode:
+                # OpenCode: Prompt already loaded via -p flag, just send Enter after 5 seconds
+                logger.info(f"OpenCode agent: Prompt loaded via -p flag, waiting 5 seconds then sending Enter")
+                await asyncio.sleep(5)
+                pane.send_keys('', enter=True)  # Send Enter to submit the prompt
+                logger.info(f"OpenCode: Enter sent to agent {agent_id}")
+            elif is_claude:
+                # Claude: Send in chunks to avoid tmux buffer issues with large prompts
+                logger.info(f"Sending initial prompt to agent {agent_id} (verification disabled)")
+                formatted_message = cli_agent.format_message(initial_message)
 
-            # Format the message first
-            formatted_message = cli_agent.format_message(initial_message)
+                chunk_size = 2500  # characters per chunk
+                num_chunks = (len(formatted_message) + chunk_size - 1) // chunk_size
+                logger.info(f"Claude agent: Sending prompt in {num_chunks} chunks ({len(formatted_message)} total chars)")
 
-            # Send in chunks to avoid tmux buffer issues with large prompts
-            chunk_size = 2500  # characters per chunk
-            num_chunks = (len(formatted_message) + chunk_size - 1) // chunk_size
-            logger.info(f"Sending prompt in {num_chunks} chunks ({len(formatted_message)} total chars)")
+                for i in range(0, len(formatted_message), chunk_size):
+                    chunk = formatted_message[i:i+chunk_size]
+                    pane.send_keys(chunk)  # No enter=True, just send the text
+                    await asyncio.sleep(0.2)  # Delay between chunks to avoid overwhelming tmux
 
-            for i in range(0, len(formatted_message), chunk_size):
-                chunk = formatted_message[i:i+chunk_size]
-                pane.send_keys(chunk)  # No enter=True, just send the text
-                await asyncio.sleep(0.2)  # Delay between chunks to avoid overwhelming tmux
+                # Now send Enter to submit the entire message
+                logger.info(f"All chunks sent, submitting message with Enter")
+                await asyncio.sleep(0.5)  # Brief pause before Enter
+                pane.send_keys('', enter=True)  # This sends just the Enter key
+                logger.info(f"Initial prompt sent to agent {agent_id}")
+            else:
+                # Other agents: Send entire prompt in one go
+                logger.info(f"Sending initial prompt to agent {agent_id} (verification disabled)")
+                formatted_message = cli_agent.format_message(initial_message)
+                logger.info(f"Non-Claude agent: Sending entire prompt in one message ({len(formatted_message)} chars)")
+                pane.send_keys(formatted_message, enter=True)
+                logger.info(f"Initial prompt sent to agent {agent_id}")
 
-            # Now send Enter to submit the entire message
-            logger.info(f"All chunks sent, submitting message with Enter")
-            await asyncio.sleep(0.5)  # Brief pause before Enter
-            pane.send_keys('', enter=True)  # This sends just the Enter key
-            logger.info(f"Initial prompt sent to agent {agent_id}")
             return
 
         # Verification enabled - retry loop
         for attempt in range(1, max_retries + 1):
             logger.info(f"Sending initial prompt to agent {agent_id} (attempt {attempt}/{max_retries})")
 
-            # Format the message first
-            formatted_message = cli_agent.format_message(initial_message)
+            if is_opencode:
+                # OpenCode: Prompt already loaded via -p flag, just send Enter after 5 seconds
+                logger.info(f"OpenCode agent: Prompt loaded via -p flag, waiting 5 seconds then sending Enter")
+                await asyncio.sleep(5)
+                pane.send_keys('', enter=True)  # Send Enter to submit the prompt
+            elif is_claude:
+                # Claude: Send in chunks to avoid tmux buffer issues with large prompts
+                formatted_message = cli_agent.format_message(initial_message)
+                chunk_size = 2000  # characters per chunk
+                num_chunks = (len(formatted_message) + chunk_size - 1) // chunk_size
+                logger.info(f"Claude agent: Sending prompt in {num_chunks} chunks ({len(formatted_message)} total chars)")
 
-            # Send in chunks to avoid tmux buffer issues with large prompts
-            chunk_size = 2000  # characters per chunk
-            num_chunks = (len(formatted_message) + chunk_size - 1) // chunk_size
-            logger.info(f"Sending prompt in {num_chunks} chunks ({len(formatted_message)} total chars)")
+                for i in range(0, len(formatted_message), chunk_size):
+                    chunk = formatted_message[i:i+chunk_size]
+                    pane.send_keys(chunk)  # No enter=True, just send the text
+                    await asyncio.sleep(0.1)  # Delay between chunks to avoid overwhelming tmux
 
-            for i in range(0, len(formatted_message), chunk_size):
-                chunk = formatted_message[i:i+chunk_size]
-                pane.send_keys(chunk)  # No enter=True, just send the text
-                await asyncio.sleep(0.1)  # Delay between chunks to avoid overwhelming tmux
-
-            # Now send Enter to submit the entire message
-            logger.info(f"All chunks sent, submitting message with Enter")
-            await asyncio.sleep(0.5)  # Brief pause before Enter
-            pane.send_keys('', enter=True)  # This sends just the Enter key
+                # Now send Enter to submit the entire message
+                logger.info(f"All chunks sent, submitting message with Enter")
+                await asyncio.sleep(0.5)  # Brief pause before Enter
+                pane.send_keys('', enter=True)  # This sends just the Enter key
+            else:
+                # Other agents: Send entire prompt in one go
+                formatted_message = cli_agent.format_message(initial_message)
+                logger.info(f"Non-Claude agent: Sending entire prompt in one message ({len(formatted_message)} chars)")
+                pane.send_keys(formatted_message, enter=True)
 
             # Verify delivery
             if await self._verify_prompt_delivery(pane, verification_string, wait_seconds=10):

--- a/src/interfaces/__init__.py
+++ b/src/interfaces/__init__.py
@@ -1,7 +1,7 @@
 """Interfaces for Hephaestus components."""
 
 from .llm_interface import LLMProviderInterface, OpenAIProvider, AnthropicProvider, LLM_PROVIDERS, get_llm_provider
-from .cli_interface import CLIAgentInterface, ClaudeCodeAgent, CodexAgent, CLI_AGENTS, get_cli_agent
+from .cli_interface import CLIAgentInterface, ClaudeCodeAgent, OpenCodeAgent, CodexAgent, CLI_AGENTS, get_cli_agent
 
 __all__ = [
     "LLMProviderInterface",
@@ -11,6 +11,7 @@ __all__ = [
     "get_llm_provider",
     "CLIAgentInterface",
     "ClaudeCodeAgent",
+    "OpenCodeAgent",
     "CodexAgent",
     "CLI_AGENTS",
     "get_cli_agent",

--- a/src/interfaces/cli_interface.py
+++ b/src/interfaces/cli_interface.py
@@ -176,6 +176,101 @@ class ClaudeCodeAgent(CLIAgentInterface):
         }
 
 
+class OpenCodeAgent(CLIAgentInterface):
+    """Implementation for OpenCode CLI (open-source alternative to Claude Code).
+
+    OpenCode supports the -p flag to pre-load a prompt, but doesn't auto-submit it.
+    We save the prompt to a temp file, launch with -p "$(cat file)", then send Enter
+    after 5 seconds to submit the prompt.
+    """
+
+    def get_launch_command(self, system_prompt: str, **kwargs) -> str:
+        """Generate launch command for OpenCode.
+
+        OpenCode's -p flag adds the prompt but doesn't auto-submit.
+        We'll save the prompt to a temp file and use -p "$(cat file)" to load it.
+        The calling code will send Enter after 5 seconds to submit.
+        """
+        import os
+        from src.core.simple_config import get_config
+
+        config = get_config()
+
+        # Save prompt to a temp file
+        task_id = kwargs.get('task_id', 'default')
+        prompt_file = f"/tmp/opencode_prompt_{task_id}.txt"
+
+        # Write the system prompt to file
+        with open(prompt_file, 'w') as f:
+            f.write(system_prompt)
+
+        # Make sure the file is readable
+        os.chmod(prompt_file, 0o644)
+
+        # Get configured model (OpenCode uses provider/model format)
+        model = getattr(config, 'cli_model', 'anthropic/claude-sonnet-4')
+
+        # OpenCode command with -p flag to load the prompt
+        # The prompt will be added to the input but not submitted
+        command = f"opencode -p \"$(cat {prompt_file})\" --model {model}"
+
+        return command
+
+    def get_health_check_pattern(self) -> str:
+        """Return health check pattern for OpenCode.
+
+        OpenCode uses a prompt indicator in its TUI.
+        """
+        return r"(›|>|opencode>)"
+
+    def format_message(self, message: str) -> str:
+        """Format message for OpenCode.
+
+        OpenCode accepts plain text messages in its TUI.
+        """
+        return message
+
+    def get_stuck_patterns(self) -> List[str]:
+        """Return stuck patterns for OpenCode."""
+        return [
+            r"rate limit exceeded",
+            r"rate limit",
+            r"API error",
+            r"connection timeout",
+            r"Error:.*API",
+            r"Failed to connect",
+            r"Maximum retries exceeded",
+            r"authentication failed",
+            r"invalid API key",
+        ]
+
+    def parse_output(self, output: str) -> Dict[str, Any]:
+        """Parse OpenCode output."""
+        lines = output.strip().split('\n')
+        last_message = ""
+        is_waiting = False
+
+        # Look for the last response before a prompt indicator
+        for i in range(len(lines) - 1, -1, -1):
+            line = lines[i]
+            if "›" in line or ">" in line or "opencode>" in line:
+                is_waiting = True
+                # Get all lines after the previous prompt as the response
+                message_lines = []
+                for j in range(i - 1, -1, -1):
+                    if "›" in lines[j] or ">" in lines[j] or "opencode>" in lines[j]:
+                        break
+                    message_lines.insert(0, lines[j])
+                last_message = "\n".join(message_lines).strip()
+                break
+
+        return {
+            "last_message": last_message,
+            "is_waiting": is_waiting,
+            "total_lines": len(lines),
+        }
+
+
 class CodexAgent(CLIAgentInterface):
     """Implementation for Codex CLI."""
 
@@ -284,6 +379,7 @@ class SwarmCodeAgent(CLIAgentInterface):
 # Registry for available CLI agents
 CLI_AGENTS = {
     "claude": ClaudeCodeAgent,
+    "opencode": OpenCodeAgent,
     "codex": CodexAgent,
     "swarm": SwarmCodeAgent,
 }
@@ -293,7 +389,7 @@ def get_cli_agent(agent_type: str) -> CLIAgentInterface:
     """Get a CLI agent instance by type.
 
     Args:
-        agent_type: Type of CLI agent (claude, codex, etc.)
+        agent_type: Type of CLI agent (claude, opencode, codex, etc.)
 
     Returns:
         CLI agent instance

--- a/website/docs/getting-started/quick-start.md
+++ b/website/docs/getting-started/quick-start.md
@@ -11,7 +11,7 @@ A simple 3-phase bug fixing workflow:
 
 ## Prerequisites
 
-- **Claude Code** installed (AI coding assistant that agents run in)
+- **Claude Code**, **OpenCode**, or **Codex** installed (CLI AI tool that agents run in)
 - **tmux** installed (terminal multiplexer for agent isolation)
 - **Git** (for worktree isolation - your project directory must be a git repo)
 - **Python 3.10+**
@@ -63,18 +63,20 @@ llm:
 
 ### Agent CLI Configuration
 
-Agents run inside **Claude Code**. Configure which Claude model to use:
+Agents run inside a CLI AI tool. Choose which CLI tool to use:
 
-**Using Claude Code (Default)**:
+#### CLI Tool Options
+
+**Claude Code (Default)**:
 ```yaml
 agents:
   default_cli_tool: "claude"
-  cli_model: "sonnet"  # or "opus", "haiku"
+  cli_model: "sonnet"  # Options: "sonnet", "opus", "haiku", "GLM-4.6"
 ```
 
-This uses your **Anthropic subscription** through Claude Code.
+Uses your **Anthropic subscription** through Claude Code. Supports Claude models and GLM-4.6 for cheaper alternative.
 
-**Using GLM-4.6 (Cheaper Alternative)**:
+**Using GLM-4.6 (cheaper model through Claude Code)**:
 ```yaml
 agents:
   default_cli_tool: "claude"
@@ -89,6 +91,25 @@ GLM_API_TOKEN=your-glm-token
 ```
 
 GLM-4.6 is significantly cheaper than Claude models while maintaining good performance.
+
+**OpenCode (Open-Source Alternative)**:
+```yaml
+agents:
+  default_cli_tool: "opencode"
+  cli_model: "anthropic/claude-sonnet-4"  # Uses provider/model format
+```
+
+**OpenCode benefits:**
+- Supports 75+ LLM providers (Anthropic, OpenAI, OpenRouter, etc.)
+- Open-source and free
+- Uses `provider/model` format (e.g., `anthropic/claude-sonnet-4`, `openai/gpt-4`)
+
+**Install OpenCode:**
+```bash
+npm install -g @opencodehq/opencode
+# or
+pip install opencode
+```
 
 ## MCP Server Setup
 

--- a/website/docs/sdk/examples.md
+++ b/website/docs/sdk/examples.md
@@ -138,6 +138,9 @@ sdk = HephaestusSDK(
     # Working directory
     working_directory=working_directory,
 
+    # Agent CLI Tool (optional - overrides config file)
+    default_cli_tool="claude",  # Options: "claude" (default), "opencode", "codex"
+
     # Server
     mcp_port=mcp_port,
     monitoring_interval=monitoring_interval,
@@ -155,6 +158,7 @@ sdk = HephaestusSDK(
 - `phases=PRD_PHASES`: Pass the Python phase objects
 - `workflow_config=PRD_WORKFLOW_CONFIG`: Configure result handling
 - LLM configuration (provider, model) comes from `hephaestus_config.yaml`, not SDK params
+- `default_cli_tool`: Optional parameter to override the CLI tool (defaults to config file setting)
 - Git paths must match: `main_repo_path == project_root == working_directory`
 - `auto_commit=True`: Agent changes are automatically committed
 

--- a/website/docs/sdk/overview.md
+++ b/website/docs/sdk/overview.md
@@ -222,6 +222,9 @@ sdk = HephaestusSDK(
     working_directory="/path/to/project",
     project_root="/path/to/project",
 
+    # Agent CLI Tool (optional - overrides config file)
+    default_cli_tool="claude",  # Options: "claude", "opencode", "codex"
+
     # Git Configuration (REQUIRED for worktree isolation)
     main_repo_path="/path/to/project",
     auto_commit=True,


### PR DESCRIPTION
Add support for OpenCode as an open-source alternative to Claude Code for running agents.

**Changes:**
- Add OpenCodeAgent class implementing CLIAgentInterface
- Implement prompt pre-loading using OpenCode's -p flag
- Handle different prompt submission strategies per agent type
- Update documentation with OpenCode setup and configuration
- Add SDK parameter to override default_cli_tool

**Features:**
- OpenCode supports 75+ LLM providers (Anthropic, OpenAI, OpenRouter, etc.)
- Uses provider/model format (e.g., "anthropic/claude-sonnet-4")
- Pre-loads prompts via temp file and -p flag
- Waits 5 seconds then sends Enter to submit

**Documentation:**
- Quick Start: Added OpenCode installation and configuration
- SDK Examples: Added default_cli_tool parameter usage
- SDK Overview: Added CLI tool configuration section

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)