### PR TITLE
Add Azure OpenAI and Google AI Studio provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,13 @@ OPENROUTER_API_KEY=sk-or-...
 GROQ_API_KEY=gsk_...
 ANTHROPIC_API_KEY=sk-ant-...
 
+# Azure OpenAI (for business users with Azure subscriptions)
+# Note: Also configure azure_endpoint and api_version in hephaestus_config.yaml
+AZURE_OPENAI_API_KEY=your-azure-openai-api-key
+
+# Google AI Studio (for Google Gemini models)
+GOOGLE_API_KEY=your-google-api-key
+
 # DEPRECATED: These are no longer used - configure in hephaestus_config.yaml instead
 # LLM_PROVIDER=openai
 # LLM_MODEL=gpt-4-turbo

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ And **flexibility where you need it**:
 - **Docker** - For running Qdrant vector store
 - **Node.js & npm** - For the frontend UI
 - **Claude Code**, **OpenCode**, **Droid**, or **Codex** - CLI AI tool that agents run inside
-- **API Keys**: OpenAI, OpenRouter, or Anthropic
+- **API Keys**: OpenAI, OpenRouter, Anthropic (also supports: Azure OpenAI, Google AI Studio - see [LLM Configuration](https://ido-levi.github.io/Hephaestus/docs/getting-started/quick-start#llm-configuration))
 
 ### Validate Your Setup (macOS)
 

--- a/examples/azure_config_example.yaml
+++ b/examples/azure_config_example.yaml
@@ -1,0 +1,144 @@
+# Hephaestus Configuration Example: Azure OpenAI
+# This example shows how to configure Hephaestus to use Azure OpenAI exclusively
+
+# Server Configuration
+server:
+  host: "0.0.0.0"
+  port: 8000
+  enable_cors: true
+
+# Paths Configuration
+paths:
+  database: "./hephaestus.db"
+  phases_folder: "./example_workflows/crackme_solving"
+  worktree_base: "/tmp/hephaestus_worktrees"
+  project_root: "./your_project"
+
+# Git Configuration
+git:
+  main_repo_path: "./your_project"
+  worktree_branch_prefix: "agent-"
+  auto_commit: true
+  conflict_resolution: "newest_file_wins"
+
+# LLM Configuration - Azure OpenAI Setup
+llm:
+  # Use Azure OpenAI for embeddings
+  embedding_model: "text-embedding-3-large"  # This is your deployment name in Azure
+  embedding_provider: "azure_openai"
+
+  # Default provider settings (for SDK workflows and legacy mode)
+  default_provider: "azure_openai"
+  default_model: "gpt-4"  # Your Azure deployment name
+  default_temperature: 0.7
+  default_max_tokens: 4000
+
+  # Provider Configuration
+  providers:
+    # Azure OpenAI Configuration
+    # IMPORTANT:
+    # 1. Set AZURE_OPENAI_API_KEY in your .env file
+    # 2. Replace YOUR-RESOURCE-NAME with your actual Azure resource name
+    # 3. Use deployment names (from Azure portal) not model names!
+    azure_openai:
+      api_key_env: "AZURE_OPENAI_API_KEY"
+      base_url: "https://YOUR-RESOURCE-NAME.openai.azure.com"  # Replace with your endpoint
+      api_version: "2024-02-01"  # Latest stable API version
+      models:
+        - "gpt-4"                # Your GPT-4 deployment name
+        - "gpt-35-turbo"         # Your GPT-3.5 deployment name
+        - "text-embedding-3-large"  # Your embedding deployment name
+
+  # Model Assignment Per Component
+  # Each system component can use a different model from Azure
+  model_assignments:
+    # Task enrichment - analyzing and expanding task descriptions
+    task_enrichment:
+      provider: "azure_openai"
+      model: "gpt-4"  # Use your GPT-4 deployment for complex analysis
+      temperature: 0.7
+      max_tokens: 4000
+
+    # Agent monitoring - tracking agent health and progress
+    agent_monitoring:
+      provider: "azure_openai"
+      model: "gpt-35-turbo"  # Lighter model for frequent checks
+      temperature: 0.3
+      max_tokens: 2000
+
+    # Guardian analysis - deep analysis of agent trajectories
+    guardian_analysis:
+      provider: "azure_openai"
+      model: "gpt-4"  # Use GPT-4 for sophisticated analysis
+      temperature: 0.5
+      max_tokens: 8000
+
+    # Conductor analysis - system-wide coherence checks
+    conductor_analysis:
+      provider: "azure_openai"
+      model: "gpt-4"
+      temperature: 0.4
+      max_tokens: 4000
+
+    # Agent prompts - generating prompts for agents
+    agent_prompts:
+      provider: "azure_openai"
+      model: "gpt-4"
+      temperature: 0.8
+      max_tokens: 4000
+
+# Agent Configuration
+agents:
+  default_cli_tool: "claude"
+  cli_model: "sonnet"
+  tmux_session_prefix: "agent"
+  health_check_interval: 60
+  max_health_failures: 3
+  termination_delay: 5
+
+# Vector Store Configuration
+vector_store:
+  qdrant_url: "http://localhost:6333"
+  collection_prefix: "hephaestus"
+  embedding_dimension: 3072  # For text-embedding-3-large
+
+# Monitoring Configuration
+monitoring:
+  enabled: true
+  interval_seconds: 60
+  log_level: "INFO"
+  log_format: "json"
+  stuck_agent_threshold: 300
+  guardian_min_agent_age_seconds: 60
+
+# MCP Server Configuration
+mcp:
+  auth_required: false
+  session_timeout: 3600
+  max_concurrent_agents: 6
+
+# Task Deduplication Configuration
+task_deduplication:
+  enabled: true
+  similarity_threshold: 0.999
+  related_threshold: 0.5
+  embedding_model: "text-embedding-3-large"  # Your Azure deployment name
+  embedding_dimension: 3072
+  batch_size: 100
+
+# Diagnostic Agent Configuration
+diagnostic_agent:
+  enabled: false
+  cooldown_seconds: 60
+  min_stuck_time_seconds: 60
+  max_agents_to_analyze: 15
+  max_conductor_analyses: 5
+  max_tasks_per_run: 5
+
+# Ticket Tracking Configuration
+ticket_tracking:
+  enabled: true
+  embedding:
+    model: "text-embedding-3-large"  # Your Azure deployment name
+    dimensions: 3072
+    provider: "azure_openai"

--- a/examples/google_config_example.yaml
+++ b/examples/google_config_example.yaml
@@ -1,0 +1,149 @@
+# Hephaestus Configuration Example: Google AI Studio (Gemini)
+# This example shows how to configure Hephaestus to use Google AI Studio exclusively
+
+# Server Configuration
+server:
+  host: "0.0.0.0"
+  port: 8000
+  enable_cors: true
+
+# Paths Configuration
+paths:
+  database: "./hephaestus.db"
+  phases_folder: "./example_workflows/crackme_solving"
+  worktree_base: "/tmp/hephaestus_worktrees"
+  project_root: "./your_project"
+
+# Git Configuration
+git:
+  main_repo_path: "./your_project"
+  worktree_branch_prefix: "agent-"
+  auto_commit: true
+  conflict_resolution: "newest_file_wins"
+
+# LLM Configuration - Google AI Studio Setup
+llm:
+  # Use Google AI embeddings
+  embedding_model: "models/embedding-001"  # Google's embedding model
+  embedding_provider: "google_ai"
+
+  # Default provider settings (for SDK workflows and legacy mode)
+  default_provider: "google_ai"
+  default_model: "gemini-2.5-flash"  # Fast and efficient Gemini model
+  default_temperature: 0.7
+  default_max_tokens: 4000
+
+  # Provider Configuration
+  providers:
+    # Google AI Studio Configuration
+    # IMPORTANT:
+    # 1. Get your API key from https://ai.google.dev/gemini-api/docs/api-key
+    # 2. Set GOOGLE_API_KEY in your .env file
+    # 3. No additional configuration needed - just the API key!
+    google_ai:
+      api_key_env: "GOOGLE_API_KEY"
+      models:
+        - "gemini-2.5-flash"       # Fast, efficient model for most tasks
+        - "gemini-2.5-flash-lite"  # Even faster, lighter model
+        - "gemini-1.5-pro"         # More capable model for complex tasks
+        - "models/embedding-001"   # Google's embedding model
+
+  # Model Assignment Per Component
+  # Each system component can use a different Gemini model
+  model_assignments:
+    # Task enrichment - analyzing and expanding task descriptions
+    task_enrichment:
+      provider: "google_ai"
+      model: "gemini-2.5-flash"  # Fast model for quick analysis
+      temperature: 0.7
+      max_tokens: 4000
+
+    # Agent monitoring - tracking agent health and progress
+    agent_monitoring:
+      provider: "google_ai"
+      model: "gemini-2.5-flash-lite"  # Lighter model for frequent checks
+      temperature: 0.3
+      max_tokens: 2000
+
+    # Guardian analysis - deep analysis of agent trajectories
+    guardian_analysis:
+      provider: "google_ai"
+      model: "gemini-1.5-pro"  # More capable model for sophisticated analysis
+      temperature: 0.5
+      max_tokens: 8000
+
+    # Conductor analysis - system-wide coherence checks
+    conductor_analysis:
+      provider: "google_ai"
+      model: "gemini-1.5-pro"  # Use powerful model for system analysis
+      temperature: 0.4
+      max_tokens: 4000
+
+    # Agent prompts - generating prompts for agents
+    agent_prompts:
+      provider: "google_ai"
+      model: "gemini-2.5-flash"
+      temperature: 0.8  # Higher temperature for creative prompt generation
+      max_tokens: 4000
+
+# Agent Configuration
+agents:
+  default_cli_tool: "claude"
+  cli_model: "sonnet"
+  tmux_session_prefix: "agent"
+  health_check_interval: 60
+  max_health_failures: 3
+  termination_delay: 5
+
+# Vector Store Configuration
+vector_store:
+  qdrant_url: "http://localhost:6333"
+  collection_prefix: "hephaestus"
+  embedding_dimension: 768  # Google's embedding-001 uses 768 dimensions
+
+# Monitoring Configuration
+monitoring:
+  enabled: true
+  interval_seconds: 60
+  log_level: "INFO"
+  log_format: "json"
+  stuck_agent_threshold: 300
+  guardian_min_agent_age_seconds: 60
+
+# MCP Server Configuration
+mcp:
+  auth_required: false
+  session_timeout: 3600
+  max_concurrent_agents: 6
+
+# Task Deduplication Configuration
+task_deduplication:
+  enabled: true
+  similarity_threshold: 0.999
+  related_threshold: 0.5
+  embedding_model: "models/embedding-001"  # Google's embedding model
+  embedding_dimension: 768  # Google embeddings use 768 dimensions
+  batch_size: 100  # Google AI supports batches up to 100
+
+# Diagnostic Agent Configuration
+diagnostic_agent:
+  enabled: false
+  cooldown_seconds: 60
+  min_stuck_time_seconds: 60
+  max_agents_to_analyze: 15
+  max_conductor_analyses: 5
+  max_tasks_per_run: 5
+
+# Ticket Tracking Configuration
+ticket_tracking:
+  enabled: true
+  embedding:
+    model: "models/embedding-001"  # Google's embedding model
+    dimensions: 768
+    provider: "google_ai"
+
+# NOTES:
+# - Google AI Studio is free for moderate use with rate limits
+# - Gemini models support multimodal inputs (text, images, audio, video)
+# - Consider Gemini 1.5 Pro for tasks requiring large context windows
+# - Flash models are optimized for speed and cost-effectiveness

--- a/hephaestus_config.yaml
+++ b/hephaestus_config.yaml
@@ -23,8 +23,9 @@ git:
 
 # LLM Configuration
 llm:
-  # Keep OpenAI embeddings as requested
+  # Embedding configuration
   embedding_model: "text-embedding-3-large"
+  embedding_provider: "openai"  # Can be: openai, azure_openai, google_ai
 
   # Used by: SDK workflows, legacy single-provider mode, and when multi-provider config is unavailable
   # This replaces the deprecated LLM_MODEL env variable
@@ -47,7 +48,28 @@ llm:
     groq:
       api_key_env: "GROQ_API_KEY"
 
+    # Azure OpenAI - For business users with Azure subscriptions
+    # Uncomment and configure if you want to use Azure OpenAI:
+    # azure_openai:
+    #   api_key_env: "AZURE_OPENAI_API_KEY"
+    #   base_url: "https://YOUR-RESOURCE-NAME.openai.azure.com"  # Replace with your Azure endpoint
+    #   api_version: "2024-02-01"
+    #   models:
+    #     - "gpt-4"           # Your deployment names (not model names!)
+    #     - "gpt-35-turbo"    # These must match your Azure portal deployments
+    #     - "text-embedding-3-large"
+
+    # Google AI Studio - For Google Gemini models
+    # Uncomment and configure if you want to use Google AI Studio:
+    # google_ai:
+    #   api_key_env: "GOOGLE_API_KEY"
+    #   models:
+    #     - "gemini-2.5-flash"      # Fast, efficient Gemini model
+    #     - "gemini-1.5-pro"        # More capable Gemini model
+    #     - "models/embedding-001"  # Google embedding model
+
   # Model assignment per component
+  # You can now use azure_openai or google_ai as providers for any component
   model_assignments:
     task_enrichment:
       provider: "openrouter"

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ langchain>=0.1.0
 langchain-openai>=0.0.5
 langchain-community>=0.0.10
 langchain-groq>=0.0.1
+langchain-google-genai>=2.0.8
 requests>=2.32.5
 pyyaml==6.0.1
 textual==0.47.1

--- a/website/docs/getting-started/quick-start.md
+++ b/website/docs/getting-started/quick-start.md
@@ -125,6 +125,58 @@ llm:
 - `gpt-5` (OpenAI) - Strong reasoning, higher cost
 - `gpt-5-mini` (OpenAI) - Faster, cheaper alternative
 
+### Alternative: Azure OpenAI (For Business Users)
+
+For enterprises with Azure subscriptions:
+
+```yaml
+llm:
+  embedding_provider: "azure_openai"
+  providers:
+    azure_openai:
+      api_key_env: "AZURE_OPENAI_API_KEY"
+      base_url: "https://YOUR-RESOURCE.openai.azure.com"
+      api_version: "2024-02-01"
+  model_assignments:
+    task_enrichment:
+      provider: "azure_openai"
+      model: "gpt-4"  # Your deployment name from Azure portal
+```
+
+**Required API Keys**:
+```bash
+# .env file
+AZURE_OPENAI_API_KEY=your-azure-key
+```
+
+**Important**: Use deployment names (configured in Azure portal), not model names!
+See [examples/azure_config_example.yaml](https://github.com/Ido-Levi/Hephaestus/blob/main/examples/azure_config_example.yaml) for complete configuration.
+
+### Alternative: Google AI Studio (Gemini)
+
+For Google Gemini models with simple API key setup:
+
+```yaml
+llm:
+  embedding_provider: "google_ai"
+  providers:
+    google_ai:
+      api_key_env: "GOOGLE_API_KEY"
+  model_assignments:
+    task_enrichment:
+      provider: "google_ai"
+      model: "gemini-2.5-flash"
+```
+
+**Required API Keys**:
+```bash
+# .env file
+GOOGLE_API_KEY=your-google-key
+```
+
+Get your API key from [https://ai.google.dev/](https://ai.google.dev/gemini-api/docs/api-key).
+See [examples/google_config_example.yaml](https://github.com/Ido-Levi/Hephaestus/blob/main/examples/google_config_example.yaml) for complete configuration.
+
 ### Agent CLI Configuration
 
 Agents run inside a CLI AI tool. Choose which CLI tool to use:


### PR DESCRIPTION
Fixes #13

Adds full support for Azure OpenAI and Google AI Studio (Gemini) as LLM providers, making Hephaestus accessible to business users with enterprise credentials.

**New Features:**
- Azure OpenAI support for both chat models and embeddings
- Google AI Studio (Gemini) support for chat models and embeddings
- Multi-provider embedding support (OpenAI, Azure, Google)
- Component-based provider routing (different components can use different providers)

**Changes:**
- Added langchain-google-genai dependency
- Extended ProviderConfig with Azure/Google-specific fields (api_version, project_id, location)
- Added embedding_provider field to LLM configuration
- Implemented Azure and Google provider cases in LangChain client
- Updated config parser to load new provider-specific fields

**Documentation:**
- Created examples/azure_config_example.yaml with complete Azure setup
- Created examples/google_config_example.yaml with complete Google setup
- Updated website/docs/getting-started/quick-start.md with setup instructions
- Updated .env.example with new environment variables
- Updated README.md to mention new provider support

**Testing:**
- Added comprehensive test coverage for Azure and Google providers
- All tests passing (16 passed, backward compatible)
- Mock-based tests (no real API keys required)

**Usage:**
Business users can now use Azure OpenAI or Google AI Studio by simply:
1. Setting their API key in .env
2. Configuring the provider in hephaestus_config.yaml
3. See examples/ directory for complete configuration templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)