### PR TITLE
fix: Add missing src/lib/utils.ts and remove lib/ from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
Fixes #14

Problem:
The frontend failed to build with "Cannot find module '@/lib/utils'" errors in 20+ components. Fresh clones of the repository couldn't start the frontend dev server because the utils.ts file was missing.

Root Cause:
The broad "lib/" pattern in .gitignore (line 13) was intended to ignore Python library directories, but it was also catching the React frontend's src/lib/ directory. This prevented frontend/src/lib/utils.ts from being tracked by git.

Solution:
- Removed the problematic "lib/" pattern from .gitignore entirely
- Created frontend/src/lib/utils.ts with the cn() utility function used by all UI components for Tailwind CSS class merging

Verification:
- Build errors reduced from 20+ import resolution errors to 0
- Dev server starts successfully on port 5173
- File is now tracked by git and will be available in fresh clones

🤖 Generated with [Claude Code](https://claude.com/claude-code)