### PR TITLE
fix: Set temperature=1.0 for GPT-5 models to resolve API errors

### DIFF
--- a/src/interfaces/langchain_llm_client.py
+++ b/src/interfaces/langchain_llm_client.py
@@ -166,12 +166,20 @@ class LangChainLLMClient:
 
         try:
             if provider == "openai":
-                return ChatOpenAI(
-                    model=assignment.model,
-                    temperature=assignment.temperature,
-                    max_tokens=assignment.max_tokens,
-                    openai_api_key=api_key
-                )
+                kwargs = {
+                    "model": assignment.model,
+                    "max_tokens": assignment.max_tokens,
+                    "openai_api_key": api_key
+                }
+
+                # GPT-5 models only support temperature=1.0 (no other values allowed)
+                # For other models, use the configured temperature
+                if assignment.model.startswith("gpt-5"):
+                    kwargs["temperature"] = 1.0
+                else:
+                    kwargs["temperature"] = assignment.temperature
+
+                return ChatOpenAI(**kwargs)
 
             elif provider == "groq":
                 return ChatGroq(


### PR DESCRIPTION
  Fixes #26

  GPT-5 models only support temperature=1.0 and reject any other values
  with a 400 error. Updated OpenAI model initialization to detect GPT-5
  models (via startswith check) and explicitly set temperature=1.0, while
  other models continue to use their configured temperature values.

  This prevents the 'Unsupported value: temperature does not support X'
  error when using gpt-5, gpt-5-turbo, or other gpt-5 variants.